### PR TITLE
Test the migrated provider against the team namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # terraform-provider-shebang
 
 The whole shebang for testing the tfe provider. This is based off of my [tfc-init repo](https://github.com/acespacecase/tfc-init) which was heavily inspired by many other similar repos internally shared at HashiCorp.
+## Setup
+
+In order to manage teams with the provider, you will need to activate the developer tier. Go to site admin, orgs, find your provider org, and upgrade it to the developer tier.
 
 ## How to use
 
@@ -19,10 +22,10 @@ Run `terraform init`, `terraform plan`, and `terraform apply`.
  - [x] tfe_policy_set_parameter
  - [x] tfe_sentinel_policy
  - [x] tfe_ssh_key
- - [ ] tfe_team
- - [ ] tfe_team_access
- - [ ] tfe_team_member
- - [ ] tfe_team_members
- - [ ] tfe_team_token
+ - [x] tfe_team
+ - [x] tfe_team_access
+ - [x] tfe_team_member
+ - [x] tfe_team_members
+ - [x] tfe_team_token
  - [x] tfe_variable
  - [x] tfe_workspace

--- a/teams.tf
+++ b/teams.tf
@@ -1,0 +1,29 @@
+resource "tfe_team" "pasta" {
+  name         = "spaghetti"
+  organization = tfe_organization.stacy_provider_vartest.name
+}
+
+resource "tfe_team" "sushi" {
+  name         = "nigiri"
+  organization = tfe_organization.stacy_provider_vartest.name
+}
+
+resource "tfe_team_access" "noodles" {
+  access       = "admin"
+  team_id      = tfe_team.sushi.id
+  workspace_id = tfe_workspace.higgins_the_cat.id
+}
+
+resource "tfe_team_member" "nsheldrick" {
+  team_id  = tfe_team.sushi.id
+  username = "nsheldrick"
+}
+
+resource "tfe_team_members" "pasta" {
+  team_id   = tfe_team.pasta.id
+  usernames = ["nsheldrick"]
+}
+
+resource "tfe_team_token" "test" {
+  team_id = tfe_team.sushi.id
+}


### PR DESCRIPTION
``` 
Terraform will perform the following actions:

  # tfe_team.pasta will be created
  + resource "tfe_team" "pasta" {
      + id           = (known after apply)
      + name         = "spaghetti"
      + organization = "stacy_provider_vartest"
    }

  # tfe_team.sushi will be created
  + resource "tfe_team" "sushi" {
      + id           = (known after apply)
      + name         = "nigiri"
      + organization = "stacy_provider_vartest"
    }

  # tfe_team_access.noodles will be created
  + resource "tfe_team_access" "noodles" {
      + access       = "admin"
      + id           = (known after apply)
      + team_id      = (known after apply)
      + workspace_id = "stacy_provider_vartest/higgins-the-cat"
    }

  # tfe_team_member.nsheldrick will be created
  + resource "tfe_team_member" "nsheldrick" {
      + id       = (known after apply)
      + team_id  = (known after apply)
      + username = "nsheldrick"
    }

  # tfe_team_members.pasta will be created
  + resource "tfe_team_members" "pasta" {
      + id        = (known after apply)
      + team_id   = (known after apply)
      + usernames = [
          + "nsheldrick",
        ]
    }

  # tfe_team_token.test will be created
  + resource "tfe_team_token" "test" {
      + id      = (known after apply)
      + team_id = (known after apply)
      + token   = (sensitive value)
    }

Plan: 6 to add, 0 to change, 0 to destroy.
``` 